### PR TITLE
Bug in F.p_value

### DIFF
--- a/distribution.gemspec
+++ b/distribution.gemspec
@@ -23,5 +23,4 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'bundler'
   s.add_development_dependency 'rake'
   s.add_development_dependency "rspec", '~> 3.2'
-  s.add_development_dependency 'rb-gsl'
 end

--- a/distribution.gemspec
+++ b/distribution.gemspec
@@ -23,4 +23,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'bundler'
   s.add_development_dependency 'rake'
   s.add_development_dependency "rspec", '~> 3.2'
+  s.add_development_dependency 'rb-gsl'
 end

--- a/lib/distribution/f/ruby.rb
+++ b/lib/distribution/f/ruby.rb
@@ -14,8 +14,9 @@ module Distribution
         # F-distribution ([1])
         # Integral over [x, \infty) 
         def q_f(df1, df2, f)
-          if (f <= 0.0) then return 1.0; end
-          if (df1 % 2 != 0 && df2 % 2 == 0)
+          return 1.0 if f <= 0.0
+
+          if df1 % 2 != 0 and df2 % 2 == 0
             return 1.0 - q_f(df2, df1, 1.0 / f)
           end
 
@@ -62,12 +63,12 @@ module Distribution
         # Inverse CDF
         # [x, \infty)
         def pf(q, n1, n2)
-          if(q < 0.0 || q > 1.0 || n1 < 1 || n2 < 1)
+          if q < 0.0 or q > 1.0 or n1 < 1 or n2 < 1
             $stderr.printf("Error : Illegal parameter in pf()!\n")
             return 0.0
           end
 
-          if n1 <= 240 || n2 <= 240
+          if n1 <= 240 or n2 <= 240
             eps = 1.0e-5
             eps = 1.0e-4 if n2 == 1
 
@@ -78,9 +79,10 @@ module Distribution
               fw += s
               return fw if s <= eps
               return fw if (qe = q_f(n1, n2, fw) - q) == 0.0
+              puts "qe #{qe} fw #{fw}"
               if qe < 0.0
                 fw -= s
-                s /= 10.0 #/
+                s /= 10.0
               end
             end
           end
@@ -107,7 +109,7 @@ module Distribution
               if(a.abs > eps)
                 fw = pfsub(a, b, d)
               else
-                if(b.abs > eps) then return -c / b end
+                return(-c / b) if b.abs > eps
                 fw = pfsub(a, b, 0.0)
               end
             end

--- a/lib/distribution/f/ruby.rb
+++ b/lib/distribution/f/ruby.rb
@@ -1,116 +1,128 @@
 module Distribution
   module F
     module Ruby_
-        class << self
+      class << self
 
-      def c_pdf(f,df)
-        Distribution::ChiSquare.pdf(f,df)
-      end
-      def pdf(x,d1,d2)
-        Math.sqrt(((d1*x)**d1*(d2**d2)).quo((d1*x+d2)**(d1+d2))).quo( x*Math.beta(d1/2.0, d2/2.0))
-      end
-      # F-distribution ([1])
-      # Integral over [x, \infty) 
-      def q_f(df1, df2, f)
-      if (f <= 0.0) then return 1.0; end
-      if (df1 % 2 != 0 && df2 % 2 == 0)
-      return 1.0 - q_f(df2, df1, 1.0 / f)
-      end
-      cos2 = 1.0 / (1.0 + df1.to_f * f / df2.to_f)
-      sin2 = 1.0 - cos2
+        def c_pdf(f,df)
+          Distribution::ChiSquare.pdf(f,df)
+        end
 
-      if (df1 % 2 == 0)
-      prob = cos2 ** (df2.to_f / 2.0)
-      temp = prob
-      i = 2
-      while i < df1
-        temp *= (df2.to_f + i - 2) * sin2 / i
-        prob += temp
-        i += 2
-      end
-      return prob
-      end
-      prob = Math.atan(Math.sqrt(df2.to_f / (df1.to_f * f)))
-      temp = Math.sqrt(sin2 * cos2)
-      i = 3
-      while i <= df1
-      prob += temp
-      temp *= (i - 1).to_f * sin2 / i.to_f;
-      i += 2.0
-      end
-      temp *= df1.to_f
-      i = 3
-      while i <= df2
-      prob -= temp
-      temp *= (df1.to_f + i - 2) * cos2 / i.to_f
-      i += 2
-      end
-      prob * 2.0 / Math::PI
-      end
+        def pdf(x,d1,d2)
+          Math.sqrt(((d1*x)**d1*(d2**d2)).quo((d1*x+d2)**(d1+d2))).quo( x*Math.beta(d1/2.0, d2/2.0))
+        end
 
-      # inverse of F-distribution ([2])
-      def pfsub(x, y, z)
-      (Math.sqrt(z) - y) / x / 2.0
-      end
+        # F-distribution ([1])
+        # Integral over [x, \infty) 
+        def q_f(df1, df2, f)
+          if (f <= 0.0) then return 1.0; end
+          if (df1 % 2 != 0 && df2 % 2 == 0)
+            return 1.0 - q_f(df2, df1, 1.0 / f)
+          end
 
-      # Inverse CDF
-      # [x, \infty)
-      def pf(q, n1, n2)
-        if(q < 0.0 || q > 1.0 || n1 < 1 || n2 < 1)
-        $stderr.printf("Error : Illegal parameter in pf()!\n")
-        return 0.0
-      end
+          cos2 = 1.0 / (1.0 + df1.to_f * f / df2.to_f)
+          sin2 = 1.0 - cos2
 
-      if n1 <= 240 || n2 <= 240
-      eps = 1.0e-5
-      if(n2 == 1) then eps = 1.0e-4 end
-      fw = 0.0
-      s = 1000.0
-      loop do
-      fw += s
-      if s <= eps  then return fw end
-      if (qe = q_f(n1, n2, fw) - q) == 0.0 then return fw end
-      if qe < 0.0
-        fw -= s
-        s /= 10.0 #/
-      end
-      end
-      end
+          if (df1 % 2 == 0)
+            prob = cos2 ** (df2.to_f / 2.0)
+            temp = prob
+            i = 2
 
-      eps = 1.0e-6
-      qn = q
-      if q < 0.5 then qn = 1.0 - q
-      u = pnorm(qn)
-      w1 = 2.0 / n1 / 9.0
-      w2 = 2.0 / n2 / 9.0
-      w3 = 1.0 - w1
-      w4 = 1.0 - w2
-      u2 = u * u
-      a = w4 * w4 - u2 * w2
-      b = -2. * w3 * w4
-      c = w3 * w3 - u2 * w1
-      d = b * b - 4 * a * c
-      if(d < 0.0)
-      fw = pfsub(a, b, 0.0)
-      else
-      if(a.abs > eps)
-        fw = pfsub(a, b, d)
-      else
-        if(b.abs > eps) then return -c / b end
-        fw = pfsub(a, b, 0.0)
-      end
-      end
-      fw * fw * fw
-      end
-      end
-      # F-distribution interface
-      def cdf(f,n1, n2)
-        1.0 - q_f(n1, n2, f)
-      end
-      def p_value(y, n1, n2)
-        pf(1.0 - y, n1, n2)
-      end
-      
+            while i < df1
+              temp *= (df2.to_f + i - 2) * sin2 / i
+              prob += temp
+              i += 2
+            end
+            return prob
+          end
+
+          prob = Math.atan(Math.sqrt(df2.to_f / (df1.to_f * f)))
+          temp = Math.sqrt(sin2 * cos2)
+          i = 3
+          while i <= df1
+            prob += temp
+            temp *= (i - 1).to_f * sin2 / i.to_f;
+            i += 2.0
+          end
+
+          temp *= df1.to_f
+          i = 3
+          while i <= df2
+            prob -= temp
+            temp *= (df1.to_f + i - 2) * cos2 / i.to_f
+            i += 2
+          end
+          prob * 2.0 / Math::PI
+        end
+
+        # inverse of F-distribution ([2])
+        def pfsub(x, y, z)
+          (Math.sqrt(z) - y) / x / 2.0
+        end
+
+        # Inverse CDF
+        # [x, \infty)
+        def pf(q, n1, n2)
+          if(q < 0.0 || q > 1.0 || n1 < 1 || n2 < 1)
+            $stderr.printf("Error : Illegal parameter in pf()!\n")
+            return 0.0
+          end
+
+          if n1 <= 240 || n2 <= 240
+            eps = 1.0e-5
+            eps = 1.0e-4 if n2 == 1
+
+            fw = 0.0
+            s  = 1000.0
+
+            loop do
+              fw += s
+              return fw if s <= eps
+              return fw if (qe = q_f(n1, n2, fw) - q) == 0.0
+              if qe < 0.0
+                fw -= s
+                s /= 10.0 #/
+              end
+            end
+          end
+
+          eps = 1.0e-6
+          qn = q
+
+          if q < 0.5
+            qn = 1.0 - q
+            u = pnorm(qn)
+            w1 = 2.0 / n1 / 9.0
+            w2 = 2.0 / n2 / 9.0
+            w3 = 1.0 - w1
+            w4 = 1.0 - w2
+            u2 = u * u
+            a = w4 * w4 - u2 * w2
+            b = -2. * w3 * w4
+            c = w3 * w3 - u2 * w1
+            d = b * b - 4 * a * c
+
+            if(d < 0.0)
+              fw = pfsub(a, b, 0.0)
+            else
+              if(a.abs > eps)
+                fw = pfsub(a, b, d)
+              else
+                if(b.abs > eps) then return -c / b end
+                fw = pfsub(a, b, 0.0)
+              end
+            end
+            fw * fw * fw
+          end
+        end
+
+        # F-distribution interface
+        def cdf(f,n1, n2)
+          1.0 - q_f(n1, n2, f)
+        end
+
+        def p_value(y, n1, n2)
+          pf(1.0 - y, n1, n2)
+        end
       end
     end
   end

--- a/spec/f_spec.rb
+++ b/spec/f_spec.rb
@@ -42,13 +42,15 @@ describe Distribution::F do
       end
     end
 
-    it_only_with_gsl "should return correct p_value" do
+    it_only_with_gsl "should return correct p_value", :focus => true do
       if @engine.respond_to? :p_value
         [0.1,0.5,1,2,10,20,30].each do |f|
           [2,5,10].each do|n2|
             [2,5,10].each do |n1|
               area = @engine.cdf(f,n1,n2)
               @engine.p_value(area,n1,n2).should be_within(1e-4).of(GSL::Cdf.fdist_Pinv(area,n1,n2))
+              @engine.p_value(0.975, 5, 4.189092917592713).should be_within(
+                1e-4).of(GSL::Cdf.fdist_Pinv(0.975, 5, 4.189092917592713))
             end
           end
         end

--- a/spec/f_spec.rb
+++ b/spec/f_spec.rb
@@ -3,68 +3,66 @@ require File.expand_path(File.dirname(__FILE__)+"/spec_helper.rb")
 include ExampleWithGSL
 
 describe Distribution::F do
-shared_examples_for "F engine(with rng)" do
-  it "should return correct rng" do
-  pending()
+  shared_examples_for "F engine(with rng)" do
+    it "should return correct rng" do
+      pending()
+    end
   end
-end
 
-shared_examples_for "F engine(with pdf)" do
-  it_only_with_gsl "should return correct pdf" do
-    if @engine.respond_to? :pdf
-      [0.1,0.5,1,2,10,20,30].each{|f|
-      [2,5,10].each{|n2|
-      [2,5,10].each{|n1|
-      @engine.pdf(f,n1,n2).should be_within(1e-4).of(GSL::Ran.fdist_pdf(f,n1,n2))
-      }
-      }
-      }
-    else
-      pending("No #{@engine}.pdf")
+  shared_examples_for "F engine(with pdf)" do
+    it_only_with_gsl "should return correct pdf" do
+      if @engine.respond_to? :pdf
+        [0.1,0.5,1,2,10,20,30].each do |f|
+          [2,5,10].each do |n2|
+            [2,5,10].each do |n1|
+              @engine.pdf(f,n1,n2).should be_within(1e-4).of(
+                GSL::Ran.fdist_pdf(f,n1,n2)
+              )
+            end
+          end
+        end
+      else
+        pending("No #{@engine}.pdf")
+      end
     end
   end
-end
 
-shared_examples_for "F engine" do
-  
-  it_only_with_gsl "should return correct cdf" do
-    if @engine.respond_to? :cdf
-      [0.1,0.5,1,2,10,20,30].each{|f|
-      [2,5,10].each{|n2|
-      [2,5,10].each{|n1|
-      @engine.cdf(f,n1,n2).should be_within(1e-4).of(GSL::Cdf.fdist_P(f,n1,n2))
-      
-      }
-      }
-      }
-    else
-      pending("No #{@engine}.cdf")
+  shared_examples_for "F engine" do
+    it_only_with_gsl "should return correct cdf" do
+      if @engine.respond_to? :cdf
+        [0.1,0.5,1,2,10,20,30].each do |f|
+          [2,5,10].each do |n2|
+            [2,5,10].each do |n1|
+              @engine.cdf(f,n1,n2).should be_within(1e-4).of(GSL::Cdf.fdist_P(f,n1,n2))        
+            end
+          end
+        end
+      else
+        pending("No #{@engine}.cdf")
+      end
     end
-  
-  end
-  it_only_with_gsl "should return correct p_value" do
-    if @engine.respond_to? :p_value
-  
-    [0.1,0.5,1,2,10,20,30].each{|f|
-    [2,5,10].each{|n2|
-    [2,5,10].each{|n1|
-    area=@engine.cdf(f,n1,n2)
-    @engine.p_value(area,n1,n2).should be_within(1e-4).of(GSL::Cdf.fdist_Pinv(area,n1,n2))
-    }
-    }
-    }
-  
-    
-    else
-      pending("No #{@engine}.p_value")
+
+    it_only_with_gsl "should return correct p_value" do
+      if @engine.respond_to? :p_value
+        [0.1,0.5,1,2,10,20,30].each do |f|
+          [2,5,10].each do|n2|
+            [2,5,10].each do |n1|
+              area = @engine.cdf(f,n1,n2)
+              @engine.p_value(area,n1,n2).should be_within(1e-4).of(GSL::Cdf.fdist_Pinv(area,n1,n2))
+            end
+          end
+        end
+      else
+        pending("No #{@engine}.p_value")
+      end
     end
   end
-end
 
   describe "singleton" do
     before do
       @engine=Distribution::F
     end
+
     it_should_behave_like "F engine"    
     it_should_behave_like "F engine(with pdf)"    
   end
@@ -76,6 +74,7 @@ end
     it_should_behave_like "F engine"    
     it_should_behave_like "F engine(with pdf)"    
   end
+
   if Distribution.has_gsl?
     describe Distribution::F::GSL_ do
       before do
@@ -84,7 +83,8 @@ end
     it_should_behave_like "F engine"    
     it_should_behave_like "F engine(with pdf)"    
     end
-  end  
+  end
+
   if Distribution.has_statistics2?
     describe Distribution::F::Statistics2_ do
       before do
@@ -103,5 +103,4 @@ end
     it_should_behave_like "F engine(with pdf)"    
     end  
   end
-  
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,8 +26,8 @@ RSpec.configure do |config|
 end
 
 module ExampleWithGSL
-  def it_only_with_gsl(name,&block)
-    it(name) do
+  def it_only_with_gsl(name,opts={},&block)
+    it(name, opts) do
       if Distribution.has_gsl?
         instance_eval(&block)
       else


### PR DESCRIPTION
@agarie: as I suspected theres a bug in the Ruby version of `Distribution::F.p_value`, which is causing a malfunction in statsample.

I've written a failing test for it, please check it out let me know what is to done, I'm not too familiar with F distributions. 

Here is the test result:

```

Failures:

  1) Distribution::F Distribution::F::Ruby_ it should behave like F engine should return correct p_value
     Failure/Error: instance_eval(&block)
       expected 20.784610000000026 to be within 0.0001 of 8.805687149846525
     Shared Example Group: "F engine" called from ./spec/f_spec.rb:76
     # ./spec/f_spec.rb:52:in `block (6 levels) in <top (required)>'
     # ./spec/f_spec.rb:49:in `each'
     # ./spec/f_spec.rb:49:in `block (5 levels) in <top (required)>'
     # ./spec/f_spec.rb:48:in `each'
     # ./spec/f_spec.rb:48:in `block (4 levels) in <top (required)>'
     # ./spec/f_spec.rb:47:in `each'
     # ./spec/f_spec.rb:47:in `block (3 levels) in <top (required)>'
     # ./spec/spec_helper.rb:32:in `instance_eval'
     # ./spec/spec_helper.rb:32:in `block in it_only_with_gsl'
```
