### PR TITLE
Complete binomial dist

### DIFF
--- a/distribution.gemspec
+++ b/distribution.gemspec
@@ -23,4 +23,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'bundler'
   s.add_development_dependency 'rake'
   s.add_development_dependency "rspec", '~> 3.2'
+  s.add_development_dependency 'pry'
 end

--- a/lib/distribution/binomial/gsl.rb
+++ b/lib/distribution/binomial/gsl.rb
@@ -57,9 +57,10 @@ module Distribution
 
         # Returns the inverse-CDF or the quantile given the probability `prob`,
         # the total number of trials `n` and the number of successes `k`
-        # Note: This is a custom implementation not derived from GSL.
-        #
-        #
+        # Note: This is a custom implementation not derived from GSL. 
+        #   Also, this is a binary search under the hood and is a candidate for
+        #   updates once more stable techniques are found
+        # 
         # @paran qn [Float] the cumulative function value to be inverted
         # @param n [Fixnum, Bignum] total number of trials
         # @param prob [Float] probabilty of success in a single independant trial
@@ -75,7 +76,6 @@ module Distribution
             mid = cdf((low + high).floor / 2, n, prob)
             lower = cdf(low, n, prob)
             upper = cdf(high, n, prob)
-            puts "#{[low, high].inspect}, #{mid}/#{qn}"
             if (qn > lower && qn < upper) && (high - low <= 1)
               # This is the only return since this
               return high

--- a/lib/distribution/binomial/gsl.rb
+++ b/lib/distribution/binomial/gsl.rb
@@ -57,13 +57,14 @@ module Distribution
 
         # Returns the inverse-CDF or the quantile given the probability `prob`,
         # the total number of trials `n` and the number of successes `k`
-        # Note: IMplementation taken from corresponding ruby code.
+        # Note: Implementation taken from corresponding ruby code.
         # 
         # @paran qn [Float] the cumulative function value to be inverted
         # @param n [Fixnum, Bignum] total number of trials
         # @param prob [Float] probabilty of success in a single independant trial
         #
         # @return [Fixnum, Bignum] the integer quantile `k` given cumulative value
+        # @raise RangeError if qn is from outside of the closed interval [0, 1]
         def quantile(qn, n, prob)
           fail RangeError, 'cdf value(qn) must be from [0, 1]. '\
             "Cannot find quantile for qn=#{qn}" if qn > 1 || qn < 0

--- a/lib/distribution/binomial/gsl.rb
+++ b/lib/distribution/binomial/gsl.rb
@@ -2,13 +2,92 @@ module Distribution
   module Binomial
     module GSL_
       class << self
+        # Returns a `Proc`object that yields a random integer `k` <= `n`
+        # which is binomially distributed with mean np and variance np(1-p)
+        # This method only wraps GSL's binomial dist. generator
+        #
+        # @param n [Fixnum] the total number of trials
+        # @param prob [Float] probabilty of success in a single independant trial
+        # @param seed [Fixnum, nil] Value to initialize the generator with.
+        #   The seed is always taken modulo 100000007. If omitted the value is
+        #   remainder of `Random.new_seed` mod 100000007
+        #
+        # @return [Proc] a proc that generates a binomially distributed integer
+        #   `k` <= `n` when called
+        def rng(n, prob, seed = nil)
+          # Method found at:
+          # SciRuby/rb-gsl/ext/gsl_native/randist.c#L1782
+          # and
+          # SciRuby/rb-gsl/ext/gsl_native/randist.c#L713
+          seed = Random.new_seed if seed.nil?
+          seed = seed.modulo 100000007
+          r = GSL::Rng.alloc(GSL::Rng::MT19937, seed)
+
+          # This is an undocumented function in rb-gsl
+          # see gsl_ran_binomial(3) in GSL manual and best guess using
+          # http://blackwinter.github.io/rb-gsl/rdoc/rng_rdoc.html
+          -> { r.binomial(prob, n) }
+        end
+
+        # Returns the probability mass function for a binomial variate
+        # having `k` successes out of `n` trials, with each success having
+        # probability `prob`.
+        #
+        # @param k [Fixnum, Bignum] number of successful trials
+        # @param n [Fixnum, Bignum] total number of trials
+        # @param prob [Float] probabilty of success in a single independant trial
+        #
+        # @return [Float] the probability mass for Binom(k, n, prob)
         def pdf(k, n, prob)
           GSL::Ran.binomial_pdf(k, prob, n)
         end
 
+        # Returns the cumulative distribution function for a binomial variate
+        # having  `k` successes out of `n` trials, with each success having
+        # probability `prob`.
+        #
+        # @param k [Fixnum, Bignum] number of successful trials
+        # @param n [Fixnum, Bignum] total number of trials
+        # @param prob [Float] probabilty of success in a single independant trial
+        #
+        # @return [Float] the probability mass for Binom(k, n, prob)
         def cdf(k, n, prob)
           GSL::Cdf.binomial_P(k, prob, n)
         end
+
+        # Returns the inverse-CDF or the quantile given the probability `prob`,
+        # the total number of trials `n` and the number of successes `k`
+        # Note: This is a custom implementation not derived from GSL.
+        #
+        #
+        # @paran qn [Float] the cumulative function value to be inverted
+        # @param n [Fixnum, Bignum] total number of trials
+        # @param prob [Float] probabilty of success in a single independant trial
+        #
+        # @return [Fixnum, Bignum] the integer quantile `k` given cumulative value
+        def quantile(qn, n, prob)
+          mid = cdf(n * prob, n, prob)
+          low, high = 0, n
+          
+          # @TODO: Ad-hoc, does a binary search, similar to newton raphson
+          # still looking for an efficient, scientifically backed method
+          while low < high
+            mid = cdf((low + high).floor / 2, n, prob)
+            lower = cdf(low, n, prob)
+            upper = cdf(high, n, prob)
+            puts "#{[low, high].inspect}, #{mid}/#{qn}"
+            if (qn > lower && qn < upper) && (high - low <= 1)
+              # This is the only return since this
+              return high
+            elsif qn < mid
+              high = (low + high) / 2
+            elsif
+              low = (low + high) / 2
+            end
+          end
+        end
+        
+        alias_method :p_value, :quantile
       end
     end
   end

--- a/lib/distribution/binomial/ruby.rb
+++ b/lib/distribution/binomial/ruby.rb
@@ -29,11 +29,13 @@ module Distribution
             # http://stackoverflow.com/q/23561551/
             log_q = Math.log(1 - prob)
             sum = 0
-            while true
-              sum += Math.log(rand) / (n - k)
-              return k if sum < log_q
-              k += 1
-            end
+            return -> {
+              while true
+                sum += Math.log(rand) / (n - k)
+                next k if sum < log_q
+                k += 1
+              end
+            }
           else
             # First principles algorithm
             # Slow and a candidate for replacement

--- a/lib/distribution/binomial/ruby.rb
+++ b/lib/distribution/binomial/ruby.rb
@@ -2,31 +2,114 @@ module Distribution
   module Binomial
     module Ruby_
       class << self
-        def pdf(k, n, pr)
-          fail 'k>n' if k > n
-          Math.binomial_coefficient(n, k) * (pr**k) * (1 - pr)**(n - k)
+        # Returns a `Proc`object that yields a random integer `k` <= `n`
+        # which is binomially distributed with mean np and variance np(1-p)
+        # This method uses a variant of Luc Devroye's 
+        # "Second Waiting Time Method" on page 522 of his text 
+        # "Non-Uniform Random Variate Generation." for np < 1e-3
+        # For all other values it finds the sum of n IID bernoulli variates
+        #
+        # @param n [Fixnum] the total number of trials
+        # @param prob [Float] probabilty of success in a single independant trial
+        # @param seed [Fixnum, nil] Value to initialize the generator with.
+        #   The seed is always taken modulo 100000007. If omitted the value is
+        #   remainder of `Random.new_seed` mod 100000007
+        #
+        # @return [Proc] a proc that generates a binomially distributed integer
+        #   `k` <= `n` when called
+        def rng(n, prob, seed = nil)
+          seed = Random.new_seed if seed.nil?
+          seed = seed.modulo 100000007
+          prng = Random.new(seed)
+          np = n * prob
+          k = 0
+          
+          if np < 1e-3
+            # An efficient technique that works for small values of `n` * `prob`
+            # http://stackoverflow.com/q/23561551/
+            log_q = Math.log(1 - prob)
+            sum = 0
+            while true
+              sum += Math.log(rand) / (n - k)
+              return k if sum < log_q
+              k += 1
+            end
+          else
+            # Accept-Reject algorithm
+            bernoulli_generator = lambda do |rng, p|
+              if rng.rand > p
+                0
+              else
+                1
+              end
+            end
+            
+            # A binomial variate is the sum of n IID bernoulli trials
+            -> {Array.new(n) { bernoulli_generator.call(prng, prob)}.reduce(:+)}
+          end
+        end
+        
+        # Returns the probability mass function for a binomial variate
+        # having `k` successes out of `n` trials, with each success having
+        # probability `prob`.
+        #
+        # @param k [Fixnum, Bignum] number of successful trials
+        # @param n [Fixnum, Bignum] total number of trials
+        # @param prob [Float] probabilty of success in a single independant trial
+        #
+        # @return [Float] the probability mass for Binom(k, n, prob)        
+        def pdf(k, n, prob)
+          fail 'k > n' if k > n
+          Math.binomial_coefficient(n, k) * (prob**k) * (1 - prob)**(n - k)
         end
 
         alias_method :exact_pdf, :pdf
 
         # TODO: Use exact_regularized_beta for
         # small values and regularized_beta for bigger ones.
-        def cdf(k, n, pr)
+        def cdf(k, n, prob)
           # (0..x.floor).inject(0) {|ac,i| ac+pdf(i,n,pr)}
-          Math.regularized_beta(1 - pr, n - k, k + 1)
+          Math.regularized_beta(1 - prob, n - k, k + 1)
         end
 
-        def exact_cdf(k, n, pr)
-          out = (0..k).inject(0) { |ac, i| ac + pdf(i, n, pr) }
+        # Returns the exact CDF value by summing up all preceding values
+        #
+        # @param k [Fixnum, Bignum] number of successful trials
+        # @param n [Fixnum, Bignum] total number of trials
+        # @param prob [Float] probabilty of success in a single independant trial
+        def exact_cdf(k, n, prob)
+          out = (0..k).inject(0) { |ac, i| ac + pdf(i, n, prob) }
           out = 1 if out > 1.0
           out
         end
-
-        def quantile(prob, n, pr)
-          ac = 0
-          (0..n).each do |i|
-            ac += pdf(i, n, pr)
-            return i if prob <= ac
+        
+        # Returns the inverse-CDF or the quantile given the probability `prob`,
+        # the total number of trials `n` and the number of successes `k`
+        # Note: This is a binary search under the hood and is a candidate for
+        #   updates once more stable techniques are found
+        #
+        # @paran qn [Float] the cumulative function value to be inverted
+        # @param n [Fixnum, Bignum] total number of trials
+        # @param prob [Float] probabilty of success in a single independant trial
+        #
+        # @return [Fixnum, Bignum] the integer quantile `k` given cumulative value
+        def quantile(qn, n, prob)
+          low, high = 0, n
+          
+          # @TODO: Ad-hoc, does a binary search, similar to newton raphson
+          # still looking for an efficient, scientifically backed method
+          while low < high
+            mid = exact_cdf((low + high).floor / 2, n, prob)
+            lower = exact_cdf(low, n, prob)
+            upper = exact_cdf(high, n, prob)
+            if (qn > lower && qn < upper) && (high - low <= 1)
+              # This is the only return since this
+              return high
+            elsif qn < mid
+              high = (low + high) / 2
+            elsif
+              low = (low + high) / 2
+            end
           end
         end
 


### PR DESCRIPTION
This PR is so far just these two  commits:
#### Changelog: Add `GSL_.rng` & `GSL_.quantile` for binomial distribution
- Added development dependency [pry](https://github.com/pry/pry) as an alternative to irb
- Documentaion done in yardoc format
- Added `Distribution::Binomial::GSL_.rng` that wraps `gsl_ran_binomial(3)`
- Added a fast but ad-hoc implementaion for binomial inverse-CDF
- Loads of comments and documentation for binomial
#### Changelog: Updated ruby implementation of inverse CDF and added RNG to `Distribution::Binomial::Ruby`
- Updated ruby quantile function to also be a binary search (O(n) -> O(log n) improvement, may be unstable; requires testing)
- Added an RNG for binomial distribution (see implementation for details)
- Updated documentation in distribution/binomial/ruby.rb
#### Updates

I ran the rspec tests one by one and found that this one gets stuck (the testcases starting on lines 70, 86 are fine)

[line 72](https://github.com/SciRuby/distribution/blob/98abb006b0ad7ecddb07db4cba7100186f130729/spec/binomial_spec.rb#L72) gets stuck for some reason. ~~Pending an analysis. Something tells me this is related to how I changed the `:p_value` method, and is resulting in a cycle(?)~~.

This was because the new `quantile` implemented made calls to `cdf`, which being slow `O(N)` died or stalled, when asked to do this for 500 x 2 x `something` test values. Removed the binary search based quantile method altogether as a result of this.

1/26/16: _Added the following commit to fix all issues and add tests:_
#### Changelog: Reverted `GSL_.quantile` and `Ruby_.quantile` for binomial distribution and added various tests for RNG
- Added RNG tests
- Reverted changes in quantile function introduced in previous commits, becuase original was ~3x(?) faster.
- ALL TESTS PASSING

This is in partial fulfillment of #21 
Maintained TODO List: https://github.com/SciRuby/distribution/issues/21#issuecomment-172246401
