### PR TITLE
Update README : Update Ubuntu/Debian gsl package name.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ $ gem install distribution
 You can install GSL for better performance:
 
 * For Mac OS X: `brew install gsl`
-* For Ubuntu / Debian: `sudo apt-get install gsl`
+* For Ubuntu / Debian: `sudo apt-get install libgsl0-dev`
 
 After successfully installing the library:
 


### PR DESCRIPTION
The Debian package name `gsl` is no longer used and is required to build the `rb-gsl` gem. The most recent name for the development package is `libgsl0-dev`.

I've updated the install line in `README.md` to hopefully save someone a few minutes of googling.
