### PR TITLE
Fix build issues by updating bundler before install per rubygems/rubygems/issues/1419

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,4 @@ script:
 before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -y libgsl0-dev
+  - sudo gem update && sudo gem install bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,4 @@ script:
 before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -y libgsl0-dev
-  - sudo gem update && sudo gem install bundler
+  - gem update && gem install bundler


### PR DESCRIPTION
Currently travis builds for distribution are failing due to an outdated bundler being used as the default one by travis. This is explained rubygems/rubygems/issues/1419. This PR's objective is to fix this issue and see if the following dependant PRs pass their respective tests (which they should)

PRs whose test status will be affected by this
1. #33  
2. #34 
3. #35 
4. #36 
5. #38 

Due to this dependency, it is better if this PR is merged prior to any of its dependents. 

Ruby 1.9.3 seems to be stalled now (2 and 2.2 have passed) @agarie @clbustos can you please check?
