### PR TITLE
Remove reference to deprecated Fixnum

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -1,3 +1,6 @@
+=== 0.7.4 / 2018-04-11
+  * Removed reference to deprecated Fixnum class.
+
 === 0.7.3 / 2015-05-28
   * Fixed F::Ruby_.p_value.
 

--- a/lib/distribution/math_extension/incomplete_beta.rb
+++ b/lib/distribution/math_extension/incomplete_beta.rb
@@ -11,7 +11,7 @@ module Distribution
           sign = nil
 
           fail(ArgumentError, 'x and y must be nonzero') if x == 0.0 || y == 0.0
-          fail(ArgumentError, 'not defined for negative integers') if [x, y].any? { |v| (v.is_a?(Fixnum) && v < 0) }
+          fail(ArgumentError, 'not defined for negative integers') if [x, y].any? { |v| v < 0 }
 
           # See if we can handle the positive case with min/max < 0.2
           if x > 0 && y > 0

--- a/lib/distribution/version.rb
+++ b/lib/distribution/version.rb
@@ -1,3 +1,3 @@
 module Distribution
-  VERSION = '0.7.3'
+  VERSION = '0.7.4'
 end


### PR DESCRIPTION
Hi friends. 

There's an unnecessary reference to a now-deprecated class (`Fixnum`) in a method to do math I don't understand that you fine folks wrote years ago that I need for calculating whether my a/b tests work.

This fixes it! There's no other references to `Fixnum` elsewhere and the type check wasn't useful anyway, so please merge it. I updated the History and bumped the version and everything.

👏 