### PR TITLE
Add poisson rng(Ruby only)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The following table lists the available distributions and the methods available 
 | Gamma            |     |     | x        | x   | x    | x    | x        | x        | x        | x       |
 | Weibull          |     |     |          | x   | x    | x    | x        | x        | x        | x       |
 | Binomial         |     |     |          | x   | x    | x    | x        | x        | x        | x       |
-| Poisson          |     |     |          | x   | x    | x    | x        | x        | x        | x       |
+| Poisson          |     |     |          |     | x    | x    | x        | x        | x        | x       |
 | Hypergeometric   |     |     |          | x   | x    | x    | x        | x        | x        | x       |
 
 ## Installation

--- a/lib/distribution/poisson/ruby.rb
+++ b/lib/distribution/poisson/ruby.rb
@@ -2,6 +2,31 @@ module Distribution
   module Poisson
     module Ruby_
       class << self
+
+        # Return a Proc object which returns a random number drawn
+        # from the poisson distribution with lambda.
+        #
+        # == Arguments
+        #   * +lambda_val+  - mean of the poisson distribution
+        #   * +seed+  - seed, an integer value to set the initial state
+        #
+        # == Algorithm
+        #   * Donald Knuth
+        #
+        def rng(lambda_val = 1, seed = nil)
+          seed = Random.new_seed if seed.nil?
+          r = Random.new(seed).rand
+          x = 0
+          l = Math.exp(-lambda_val)
+          s = l
+          while r > s
+            x += 1
+            l *= lambda_val / x.to_f
+            s += l
+          end
+          x
+        end
+
         def pdf(k, l)
           (l**k * Math.exp(-l)).quo(Math.factorial(k))
         end

--- a/spec/poisson_spec.rb
+++ b/spec/poisson_spec.rb
@@ -3,12 +3,14 @@ include ExampleWithGSL
 describe Distribution::Poisson do
   shared_examples_for 'poisson engine(with rng)' do
     it 'should return correct rng' do
-      lambda_val = 2
-      exp_mean = 2
-      exp_seed = 1
+      # The expected rng output when 1 is set as the seed value
+      exp_means = [1, 2, 2, 3, 4, 5, 6, 7, 8, 9]
 
-      # if seed = "1" / lambda_val = 2, rng is expected to all "2"
-      rng = @engine.rng(lambda_val, exp_seed)
+      lambda_val = rand(10) + 1
+      exp_mean = exp_means[lambda_val - 1]
+      seed = 1
+
+      rng = @engine.rng(lambda_val, seed)
 
       samples = 100
       sum = 0
@@ -17,13 +19,13 @@ describe Distribution::Poisson do
         sum += v
       end
       mean = sum / samples
-      expect(mean.to_i).to be_within(1e-10).of(2)
+      expect(mean.to_i).to be_within(1e-10).of(exp_mean)
     end
   end
 
   shared_examples_for 'poisson engine(with rng)' do
     it 'rng with a specified seed should be reproducible' do
-      seed = rand(10)
+      seed = 1
       rng1 = @engine.rng(3, seed)
       rng2 = @engine.rng(3, seed)
       expect((rng1.call)).to eq(rng2.call)

--- a/spec/poisson_spec.rb
+++ b/spec/poisson_spec.rb
@@ -21,7 +21,7 @@ describe Distribution::Poisson do
     end
   end
 
-  shared_examples_for 'gaussian engine(with rng)' do
+  shared_examples_for 'poisson engine(with rng)' do
     it 'rng with a specified seed should be reproducible' do
       seed = 1
       rng1 = @engine.rng(3, seed)

--- a/spec/poisson_spec.rb
+++ b/spec/poisson_spec.rb
@@ -17,13 +17,13 @@ describe Distribution::Poisson do
         sum += v
       end
       mean = sum / samples
-      expect(mean.to_i).to 2
+      expect(mean.to_i).to be_within(1e-10).of(2)
     end
   end
 
   shared_examples_for 'poisson engine(with rng)' do
     it 'rng with a specified seed should be reproducible' do
-      seed = 1
+      seed = rand(10)
       rng1 = @engine.rng(3, seed)
       rng2 = @engine.rng(3, seed)
       expect((rng1.call)).to eq(rng2.call)

--- a/spec/poisson_spec.rb
+++ b/spec/poisson_spec.rb
@@ -24,8 +24,8 @@ describe Distribution::Poisson do
   shared_examples_for 'gaussian engine(with rng)' do
     it 'rng with a specified seed should be reproducible' do
       seed = 1
-      rng1 = @engine.rng(3, 1, seed)
-      rng2 = @engine.rng(3, 1, seed)
+      rng1 = @engine.rng(3, seed)
+      rng2 = @engine.rng(3, seed)
       expect((rng1.call)).to eq(rng2.call)
     end
   end

--- a/spec/poisson_spec.rb
+++ b/spec/poisson_spec.rb
@@ -1,6 +1,36 @@
 require File.expand_path(File.dirname(__FILE__) + '/spec_helper.rb')
 include ExampleWithGSL
 describe Distribution::Poisson do
+  shared_examples_for 'poisson engine(with rng)' do
+    it 'should return correct rng' do
+      lambda_val = 2
+      exp_mean = 2
+      exp_seed = 1
+
+      # if seed = "1" / lambda_val = 2, rng is expected to all "2"
+      rng = @engine.rng(lambda_val, exp_seed)
+
+      samples = 100
+      sum = 0
+      samples.times do
+        v = rng.call
+        sum += v
+      end
+      mean = sum / samples
+      expect(mean.to_i).to 2
+    end
+  end
+
+  shared_examples_for 'gaussian engine(with rng)' do
+    it 'rng with a specified seed should be reproducible' do
+      seed = 1
+      rng1 = @engine.rng(3, 1, seed)
+      rng2 = @engine.rng(3, 1, seed)
+      expect((rng1.call)).to eq(rng2.call)
+    end
+  end
+
+
   shared_examples_for 'poisson engine' do
     it 'should return correct pdf' do
       if @engine.respond_to? :pdf


### PR DESCRIPTION
https://github.com/SciRuby/distribution/issues/13
I added rng function of Poisson distribution(Ruby only).
Could you check it?

I would like to add rng function for the remaining distribution.